### PR TITLE
fixed bug #73

### DIFF
--- a/src/js/app/response.js
+++ b/src/js/app/response.js
@@ -2,7 +2,7 @@ define(function(){
   
   const makeResponse = ({content = {}, headers = [],status,duration = 0}) => ({content,headers,status,duration});
   
-  const parseHeaders = headers =>
+  const parseHeaders = (headers = '') =>
       headers.trim().split('\n')
         .map(header =>
           header.split(':')


### PR DESCRIPTION
Just added the default value for the `headers` parameter and looks like it's working now.

Before it just logged an error on the console and the body response doesn't appears.

Just running the request again at it worked.

Now it should work on the first request too.

