### PR TITLE
Fix issue #169

### DIFF
--- a/src/js/app/response.js
+++ b/src/js/app/response.js
@@ -24,7 +24,7 @@ define(function(){
   const parseHeaders = (headers = '') =>
       headers.trim().split('\n')
         .map(header =>
-          header.split(':')
+          header.split(/:(.*)/)
             .map(h => h.trim()))
         .map(headerFields => ({ name: headerFields[0], value: headerFields[1] }));
   


### PR DESCRIPTION
Closes #169 

Update split in `parseHeaders` function.

Using only `":"` is matching all instances and hence the original issue
`[ "date", " 12 Nov 1994 11", "12", "13" ]`

Using `/:(.*)/` will match the first part and remaining is captured as is
[MDN doc link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split#splitting_with_a_regexp_to_include_parts_of_the_separator_in_the_result)
`[ "date", " 12 Nov 1994 11:12:13", "" ]` 

P.S: Sorry for constantly pushing PR's, I just have some time and thought of fixing some bugs.
