### PR TITLE
Add new shortcut to send a request

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -166,7 +166,7 @@
           <li role="presentation" data-bind="css: {active : showActiveContext()}"><a href="#" data-bind="click: contextPanel">Context</a></li>
         </ul>
 
-        <div class="panel panel-default" style="padding: 10px;">
+        <div class="panel panel-default" style="padding: 10px;" data-bind="event: { keyup: callSendOnCtrlEnter }">
           <div class="panel-body">
             <request-body params="request: request" data-bind="visible : showRequestBody"></request-body>
             <entry-list params="entryList : request.headers" data-bind="visible : showRequestHeaders"></entry-list>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -632,6 +632,13 @@ const REQUEST_STATE_MAP = {
       }
     };
 
+    const callSendOnCtrlEnter = (data, event) => {
+      const enter = 13;
+      if(event.ctrlKey && event.keyCode === enter) {
+        send();
+      }
+    }
+
     const closeDialogOnExcape = (data, event) => {
       const excape = 27;
       if(event.keyCode === excape) {
@@ -844,6 +851,7 @@ const REQUEST_STATE_MAP = {
     Resting.dataToSend = dataToSend;
     Resting.deleteBookmark = deleteBookmark;
     Resting.callSendOnEnter = callSendOnEnter;
+    Resting.callSendOnCtrlEnter = callSendOnCtrlEnter;
 
     Resting.send = send;
     Resting.saveBookmark = saveBookmark;


### PR DESCRIPTION
As there are many input fields in the panel (Headers, Body, Querystring etc), instead of adding event listeners on each element I have added a `keyup` event to the wrapping div. Now if any input in the panel is in focus, it's now possible to use `Ctrl + Enter` to call the API.

Closed #174 