### PR TITLE
Update tab behavior to keep one open at all times

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -121,12 +121,14 @@
         <li role="presentation" data-bind="css: {active : $data.isActive}">
           <a href="#" data-bind="click: $parent.activateTab">
             <span data-bind="text: $data.name"></span>
-            <button
-              type="button"
-              class="btn btn-xs btn-danger"
-              data-bind="click: $parent.removeTab, clickBubble: false">
-              <span class="glyphicon glyphicon-remove"></span>
-            </button>
+            <span data-bind="visible: $data.showRemoveTabButton">
+              <button
+                type="button"
+                class="btn btn-xs btn-danger"
+                data-bind="click: $parent.removeTab, clickBubble: false">
+                <span class="glyphicon glyphicon-remove"></span>
+              </button>
+            </span>
           </a>
         </li>
         <!-- /ko -->

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -844,6 +844,13 @@ requirejs(
 
       const newTab = () => {
         const newTabContext = new TabContextVm(++tabCounter)
+        if (tabContexts().length === 0) {
+          newTabContext.showRemoveTabButton(false)
+        }
+        if (tabContexts().length === 1) {
+          const prevTabContext = tabContexts()[0]
+          prevTabContext.showRemoveTabButton(true)
+        }
         tabContexts.push(newTabContext)
         _activateTab(newTabContext)
       }
@@ -855,6 +862,11 @@ requirejs(
           _activateTab(tabContexts()[Math.abs(tabToRemoveIndex - 1)])
         }
         tabContexts.remove(tab)
+
+        if (tabContexts().length === 1) {
+          const lastTab = tabContexts()[0]
+          lastTab.showRemoveTabButton(false)
+        }
       }
 
       const enableSaveButton = () => {

--- a/src/js/app/components/bookmarks/bookmarks_view.html
+++ b/src/js/app/components/bookmarks/bookmarks_view.html
@@ -134,7 +134,6 @@
         Remove
         <i class="glyphicon glyphicon-trash pull-right"></i>
       </li>
-      <li class="list-group-item ctx-menu-item"></li>
     </ul>
   </div>
 

--- a/src/js/app/tabContextVm.js
+++ b/src/js/app/tabContextVm.js
@@ -13,6 +13,7 @@ define(['knockout', 'app/bookmarkSelectedVm'], function (
     this.bookmarkSelected = new BookmarkSelectedVm()
 
     this.isActive = ko.observable(false)
+    this.showRemoveTabButton = ko.observable(true)
 
     this.reset = () => {
       this.request = {}


### PR DESCRIPTION
closes #204 & minor context menu UI issue

### fix issue 204
This change does not show `x` remove tab button if there is only one tab.
- when extension is opened for first time
![image](https://github.com/mirkoperillo/resting/assets/61220506/3fea20bb-1d5d-4251-806e-649ef06c8b37)

- after clicking on new tab `+`
![image](https://github.com/mirkoperillo/resting/assets/61220506/1ad22fe8-0b26-4495-a15a-63633d26b2a8)

- after closing one of the two tabs
![image](https://github.com/mirkoperillo/resting/assets/61220506/3d305d0d-d6ea-4da2-a3d0-ff317c85136e)

### context menu UI issue
This change also includes one minor UI issue. Removes empty `li` in bookmark context menu. I included it here as it is a small change. Can split it up into new PR if needed
![326423266-8362aa0d-430a-4749-90ac-8f8cfe04be23](https://github.com/mirkoperillo/resting/assets/61220506/215b569f-4706-4a84-b749-398b3c4a4c6a)
